### PR TITLE
Updated Google Maps API Key

### DIFF
--- a/src/Explore/Views/map.twig
+++ b/src/Explore/Views/map.twig
@@ -23,7 +23,7 @@
     
     {{ block('bootstrapCore')}}
     <script src='/js/map.js'></script>
-    <script src='https://maps.googleapis.com/maps/api/js?key=AIzaSyDglONa03SLsLkWrBbCL0WFYOeAhNKrpJI&libraries=visualization&callback=initAutocomplete'
+    <script src='https://maps.googleapis.com/maps/api/js?key=AIzaSyBoLz-o0RsflcMv8lZpi3i3xiN6go5U3AE&libraries=visualization&callback=initAutocomplete'
         async defer></script>
     
 </body>


### PR DESCRIPTION
Google deleted the Hercules API project keys so they had to be regenerated. This is the new key.